### PR TITLE
Chart image tweaks

### DIFF
--- a/modules/class-simplechart-save.php
+++ b/modules/class-simplechart-save.php
@@ -9,17 +9,12 @@ class Simplechart_Save {
 	private $_show_debug_messages = false;
 
 	function __construct(){
-		add_action( 'save_post', array( $this, 'save_post_action' ), 10, 1 );
+		add_action( 'save_post_simplechart', array( $this, 'save_post_action' ), 10, 1 );
 		add_action( 'admin_notices', array( $this, 'admin_notices' ) );
 	}
 
 	// use remove-add to prevent infinite loop
 	function save_post_action( $post_id ){
-
-		//ignore all other post types
-		if ( 'simplechart' !== get_post_type( $post_id ) ){
-			return;
-		}
 
 		// verify nonce
 		if ( empty( $_POST['simplechart-nonce'] ) || ! wp_verify_nonce( $_POST['simplechart-nonce'], 'simplechart_save' ) ){
@@ -36,10 +31,10 @@ class Simplechart_Save {
 			return;
 		}
 
-		remove_action( 'save_post', array($this, 'save_post_action' ), 10, 1 );
+		remove_action( 'save_post_simplechart', array($this, 'save_post_action' ), 10, 1 );
 		$post = get_post( $post_id );
 		$this->do_save_post( $post );
-		add_action( 'save_post', array($this, 'save_post_action' ), 10, 1 );
+		add_action( 'save_post_simplechart', array($this, 'save_post_action' ), 10, 1 );
 	}
 
 	function admin_notices(){

--- a/modules/class-simplechart-save.php
+++ b/modules/class-simplechart-save.php
@@ -85,7 +85,7 @@ class Simplechart_Save {
 			// store data URI for future post so it can be saved as image later
 			elseif ( 'future' === get_post_status( $post->ID ) ) {
 				update_post_meta( $post->ID, $this->_data_uri_key, sanitize_text_field( $_POST['simplechart-png-string'] ) );
-				error_log( 'saved data URI to post meta' );
+				error_log( 'saved data URI to post meta for ' . $post->ID );
 			}
 		}
 
@@ -129,9 +129,19 @@ class Simplechart_Save {
 
 	private function _save_chart_image( $post, $data_uri, $img_type ){
 
+		// make sure we have a post object
 		if ( is_numeric( $post ) ) {
 			$post = get_post( $post );
 		}
+
+		// may be applicable during WP Cron
+		if ( ! function_exists( 'media_handle_sideload' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/media.php' );
+		}
+		if ( ! function_exists( 'wp_handle_sideload' ) ) {
+			require_once( ABSPATH . 'wp-admin/includes/file.php' );
+		}
+
 
 		$perm_file_name = 'simplechart_' . $post->ID . '.' . $img_type;
 		$temp_file_name = 'temp_' . $perm_file_name;

--- a/modules/class-simplechart-save.php
+++ b/modules/class-simplechart-save.php
@@ -68,8 +68,10 @@ class Simplechart_Save {
 	function do_save_post( $post ){
 
 		// handle base64 image string if provided
-		if ( ! empty( $_POST['simplechart-png-string'] ) ){
+		if ( ! empty( $_POST['simplechart-png-string'] ) && 'publish' === $post->post_status ){
 			$this->_save_chart_image( $post, $_POST['simplechart-png-string'], $this->_default_img_type );
+		} elseif ( 'publish' !== $post->post_status && has_post_thumbnail( $post->ID ) ){
+			wp_delete_attachment( get_post_thumbnail_id( $post->ID ), true );
 		}
 
 		// sanitize and validate JSON formatting of chart data

--- a/modules/class-simplechart-save.php
+++ b/modules/class-simplechart-save.php
@@ -171,16 +171,16 @@ class Simplechart_Save {
 
 		// import to media library
 		$desc = 'Chart: ' . sanitize_text_field( get_the_title( $post->ID ) );
-		$attachment_id = media_handle_sideload( array(
+		$this->_attachment_id = media_handle_sideload( array(
 			'name' => $perm_file_name,
 			'tmp_name' => $temp_file['file'],
 		), $post->ID, $desc);
-		$new_file_path = get_post_meta( $attachment_id, '_wp_attached_file', true );
+		$new_file_path = get_post_meta( $this->_attachment_id, '_wp_attached_file', true );
 		$this->_debug_messages[] = sprintf( __( 'media_handle_sideload() to %s', 'simplechart' ), $new_file_path );
 		$this->_debug_messages[] = $new_file_path === $old_file_path ? __( 'New file path matches old file path', 'simplechart' ) : __( 'New file path does NOT match old file path', 'simplechart' );
 
-		if ( is_wp_error( $attachment_id ) ){
-			$this->_errors = array_merge( $this->_errors, $attachment_id->get_error_messages() );
+		if ( is_wp_error( $this->_attachment_id ) ){
+			$this->_errors = array_merge( $this->_errors, $this->_attachment_id->get_error_messages() );
 			return false;
 		}
 
@@ -190,10 +190,7 @@ class Simplechart_Save {
 		}
 
 		// set as post featured image
-		set_post_thumbnail( $post->ID, $attachment_id );
-
-		// use custom post status
-		$this->_attachment_id = $attachment_id;
+		set_post_thumbnail( $post->ID, $this->_attachment_id );
 
 		// delete the temporary file!
 		if ( file_exists( $temp_file['file'] ) ){


### PR DESCRIPTION
- Only create an image version of the chart from its data URI when the chart's status is `publish` or `future`
- Use a custom post status for the image so it doesn't show up in the regular media library
