### PR TITLE
Import command for WPCOM API

### DIFF
--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -57,15 +57,17 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 		$post_ids = array_map( 'absint', $post_ids );
 		$site_id = absint( $assoc_args['site'] );
 		$this->_set_author( $assoc_args );
-		WP_CLI::line( sprintf( __( 'Starting import of %s posts from site %s', 'simplechart' ), count( $post_ids ), $site_id ) );
+		WP_CLI::line( sprintf( __( "Starting import of %s posts from site %s\n", 'simplechart' ), count( $post_ids ), $site_id ) );
 		foreach ( $post_ids as $post_id ) {
+			WP_CLI::line( sprintf( __( 'Processing post %s', 'simplechart' ), $post_id ) );
 			$post_object = $this->_extract_wpcom_post_object( $site_id, $post_id );
 			if ( $post_object ) {
 				$transformed = $this->_transform_from_wpcom_api( $post_object );
 				$this->_load_post( $transformed );
 			}
+			WP_CLI::line( '' );
 		}
-		WP_CLI::success( sprintf( __( 'Processed %s posts from site %s', 'simplechart' ), count( $post_ids ), $site_id ) );
+		WP_CLI::line( sprintf( __( 'Processed %s posts from site %s', 'simplechart' ), count( $post_ids ), $site_id ) );
 	}
 
 	/**

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Import Simplechart charts from a remote site via WP-CLI
+ */
+
+class Simplechart_WP_CLI extends WP_CLI_Command {
+
+	/**
+	 * Imports Simplechart charts using the Jetpack/WPCOM REST API
+	 *
+	 * ## OPTIONS
+	 *
+	 * --site_id=<site_id>
+	 * : WPCOM site ID
+	 *
+	 * --posts=<post_ids>
+	 * : comma separated list of Simplechart post IDs on remote site
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp simplechart import_wpcom --site_id=123456 --posts=12,13,14
+	 *
+	 * @synopsis --site_id=<site_id> --posts=<post_ids>
+	 */
+	function import_wpcom( $args, $assoc_args ) {
+		$post_ids = explode( ',', $assoc_args['posts'] );
+		$post_ids = array_map( 'absint', $post_ids );
+
+	}
+
+}
+WP_CLI::add_command( 'simplechart', 'Simplechart_WP_CLI' );

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -3,31 +3,221 @@
 /**
  * Import Simplechart charts from a remote site via WP-CLI
  */
-
 class Simplechart_WP_CLI extends WP_CLI_Command {
+
+	/**
+	 * @var string $_wpcom_api_url Templatized URL to retrieve a single post from the WordPress.com REST API
+	 */
+	private $_wpcom_api_url = 'https://public-api.wordpress.com/rest/v1.1/sites/{{site}}/posts/{{post}}';
+
+	/**
+	 * @var int|string|null $_author Author ID to assign imported posts to
+	 */
+	private $_author = null;
+
+	/**
+	 * @var string $_post_type The post type we want to work with
+	 */
+	private $_post_type = 'simplechart';
+
+	/**
+	 * @var array $_meta_keys List of post meta keys to set when creating a post
+	 */
+	private $_meta_keys = array(
+		'simplechart-data',
+		'simplechart-template',
+		'simplechart-chart-url',
+		'simplechart-chart-id',
+		'simplechart-errors',
+	);
 
 	/**
 	 * Imports Simplechart charts using the Jetpack/WPCOM REST API
 	 *
 	 * ## OPTIONS
 	 *
-	 * --site_id=<site_id>
+	 * --site=<site_id>
 	 * : WPCOM site ID
 	 *
 	 * --posts=<post_ids>
 	 * : comma separated list of Simplechart post IDs on remote site
 	 *
+	 *
+	 * [--author=<author>]
+	 * : Assigns imported posts to a specific author ID or username
+	 *
 	 * ## EXAMPLES
 	 *
-	 * wp simplechart import_wpcom --site_id=123456 --posts=12,13,14
+	 * wp simplechart import_wpcom --site=123456 --posts=12,13,14 --author=6
 	 *
-	 * @synopsis --site_id=<site_id> --posts=<post_ids>
+	 * @synopsis --site=<site_id> --posts=<post_ids> [--author=<author_id>]
 	 */
 	function import_wpcom( $args, $assoc_args ) {
 		$post_ids = explode( ',', $assoc_args['posts'] );
 		$post_ids = array_map( 'absint', $post_ids );
-
+		$site_id = absint( $assoc_args['site'] );
+		$this->_set_author( $assoc_args );
+		WP_CLI::line( sprintf( 'Starting import of %s posts from site %s', count( $post_ids ), $site_id ) );
+		foreach ( $post_ids as $post_id ) {
+			$post_object = $this->_extract_wpcom_post_object( $site_id, $post_id );
+			if ( $post_object ) {
+				$transformed = $this->_transform_from_wpcom_api( $post_object );
+				$this->_load_post( $transformed );
+			}
+		}
+		WP_CLI::success( sprintf( 'Processed %s posts from site %s', count( $post_ids ), $site_id ) );
 	}
 
+	/**
+	 * set author by ID or username to assign imported posts to
+	 * @var array Assoc args from command
+	 */
+	private function _set_author( $assoc_args ) {
+		// was an author provided?
+		if ( empty( $assoc_args['author'] ) ) {
+			return;
+		}
+
+		// check for author ID
+		if ( is_numeric( $assoc_args['author'] ) ) {
+			$user = get_user_by( 'id', absint( $assoc_args['author'] ) );
+		}
+		// check for author by slug
+		else {
+			$user = get_user_by( 'slug', $assoc_args['author'] );
+		}
+
+		// set author
+		if ( ! empty( $user ) ) {
+			$this->_author = $user->ID;
+		}
+		return;
+	}
+
+	/**
+	 * Retrieve a single post from the WordPress.com REST API
+	 * see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/#apidoc-response
+	 * @param int $site WPCOM site ID
+	 * @param int $post WPCOM post ID
+	 * @return array Associative array of JSON response
+	 */
+	private function _extract_wpcom_post_object( $site, $post ) {
+		// build API url
+		$url = str_replace( '{{site}}', $site, $this->_wpcom_api_url );
+		$url = str_replace( '{{post}}', $post, $url );
+
+		// API request
+		$response = wp_remote_get( $url );
+
+		// validate response
+		if ( is_wp_error( $response ) ) {
+			$warning = sprintf( "Failed to GET post %s from site %s\n", $post, $site );
+			$warning .= implode( "\n", $response->get_error_messages() );
+			WP_CLI::warning( $warning );
+			return null;
+		} elseif ( 200 !== $code = wp_remote_retrieve_response_code( $response ) ) {
+			WP_CLI::warning( sprintf( 'Post %s from site %s returned error code %s', $post, $site, $code ) );
+			return null;
+		}
+
+		$post_object = json_decode( wp_remote_retrieve_body( $response ), true );
+
+		// make sure it's the right post type
+		if ( $this->_post_type !== $post_object['type'] ) {
+			WP_CLI::warning( sprintf( "Post %s from site %s does not have post_type '%s'", $post, $site, $this->_post_type ) );
+			return null;
+		}
+
+		return $post_object;
+	}
+
+	/**
+	 * Create a post in Simplechart post type using WPCOM REST API data
+	 * @param array $post_object API data for the post
+	 * @return array Post object transformed for our data loader
+	 */
+	private function _transform_from_wpcom_api( $post_object ) {
+		// basic post info
+		$post_data = array(
+			'post_name' => $post_object['slug'],
+			'post_title' => $post_object['title'],
+			'post_status' => $post_object['status'],
+			'post_type' => $this->_post_type,
+			'post_date_gmt' => date( 'Y-m-d H:i:s', strtotime( $post_object['date'] ) ),
+		);
+
+		// author ID if we have one
+		if ( $this->_author ) {
+			$post_data['post_author'] = $this->_author;
+		}
+
+		// loop through post metadata
+		$post_meta = array();
+		if ( ! empty( $post_object['metadata'] ) && is_array( $post_object['metadata'] ) ) {
+			foreach ( $post_object['metadata']  as $meta ) {
+				if ( in_array( $meta['key'], $this->_meta_keys, true ) ) {
+					$post_meta[ $meta['key'] ] = $meta['value'];
+				}
+			}
+		}
+
+		// featured image
+		$featured_image = null;
+		if ( ! empty( $post_object['post_thumbnail' ] ) ) {
+			$featured_image = array(
+				'url' => $post_object['post_thumbnail' ]['URL'],
+				'width' => $post_object['post_thumbnail' ]['width'],
+				'height' => $post_object['post_thumbnail' ]['height'],
+			);
+		}
+
+		return array(
+			'post_data' => $post_data,
+			'post_meta' => $post_meta,
+			'featured_image' => $featured_image,
+		);
+	}
+
+	/**
+	 * create new post for the chart, using already transformed data
+	 * @var array $data Post data for new chart
+	 *			array 'post_data' Arguments to pass to wp_insert_post()
+	 *			array 'post_meta' Key-value pairs to set as post meta
+	 *			array 'featured_image' Optional array of url, width, height of image to import
+	 * @return bool Success or failure
+	 */
+	private function _load_post( $data ) {
+		if ( empty( $data['post_data'] ) ) {
+			WP_CLI::warning( 'Tried to insert post with no post_data' );
+			return false;
+		}
+
+		// create the post
+		$post_id = wp_insert_post( $data['post_data'] );
+		if ( 0 === $post_id ) {
+			return false;
+		}
+
+		// add the post metadata
+		foreach ( $data['post_meta'] as $key => $value ) {
+			update_post_meta( $post_id, $key, $value );
+		}
+
+		// attach the featured image
+		if ( $post_data['featured_image'] ) {
+			$this->_attach_featured_image_to_post( $post_data['featured_image'], $post_id );
+		}
+
+		return true;
+	}
+
+	/**
+	 * sideload featured image from URL and set as post thumbnail
+	 * @var array $image Image URL, width, height
+	 * @var int $post_id ID of Simplechart post
+	 */
+	private function _attach_featured_image_to_post( $image, $post_id ) {
+		// https://codex.wordpress.org/Function_Reference/media_handle_sideload#Examples
+	}
 }
 WP_CLI::add_command( 'simplechart', 'Simplechart_WP_CLI' );

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -102,6 +102,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 			return null;
 		}
 
+		WP_CLI::success( sprintf( __( 'Retrieved post %s from site %s', 'simplechart' ), $post, $site ) );
 		return $post_object;
 	}
 
@@ -135,7 +136,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 			}
 		}
 
-		// featured image
+		// featured image URL
 		$featured_image = ! empty( $post_object['featured_image'] ) ? $post_object['featured_image'] : null;
 
 		return array(
@@ -155,13 +156,14 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 	 */
 	private function _load_post( $data ) {
 		if ( empty( $data['post_data'] ) ) {
-			WP_CLI::warning( __( 'Tried to insert post with no post_data', 'simplechart' ) );
+			WP_CLI::warning( __( 'Cannot insert post with no post_data', 'simplechart' ) );
 			return false;
 		}
 
 		// create the post
 		$post_id = wp_insert_post( $data['post_data'] );
 		if ( 0 === $post_id ) {
+			WP_CLI::warning( __( 'Failed to insert post', 'simplechart' ) );
 			return false;
 		}
 
@@ -202,6 +204,9 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 
 		if ( ! is_wp_error( $media_id ) ) {
 			set_post_thumbnail( $post_id, $media_id );
+			WP_CLI::success( sprintf( __( 'Set attachment %s as thumbnail for post %s', 'simplechart' ), $media_id, $post_id ) );
+		} else {
+			WP_CLI::warning( sprintf( __( 'Sideload failed: %s', 'simplechart' ), $media_id->get_error_message() ) );
 		}
 		if ( file_exists( $tmp ) ) {
 			@unlink( $tmp );

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -126,8 +126,10 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 			$post_data['post_author'] = $this->_author;
 		}
 
-		// loop through post metadata
-		$post_meta = array();
+		// setup post metadata
+		$post_meta = array(
+			'_src_guid' => $post_data['guid'],
+		);
 		if ( ! empty( $post_object['metadata'] ) && is_array( $post_object['metadata'] ) ) {
 			foreach ( $post_object['metadata']  as $meta ) {
 				if ( in_array( $meta['key'], $this->_meta_keys, true ) ) {

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -98,6 +98,12 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 
 		$post_object = json_decode( wp_remote_retrieve_body( $response ), true );
 
+		// make sure json_decode worked
+		if ( empty( $post_object ) ) {
+			WP_CLI::warning( sprintf( __( 'Invalid JSON response from %s', 'simplechart' ), $url ) );
+			return null;
+		}
+
 		// make sure it's the right post type
 		if ( $this->_post_type !== $post_object['type'] ) {
 			WP_CLI::warning( sprintf( __( "Post %s from site %s does not have post_type '%s'", 'simplechart' ), $post, $site, $this->_post_type ) );
@@ -186,7 +192,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 
 	/**
 	 * sideload featured image from URL and set as post thumbnail
-	 * @var array $image Image URL
+	 * @var string $image Image URL
 	 * @var int $post_id ID of Simplechart post
 	 * @var string $desc Description for image
 	 */

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -57,7 +57,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 		$post_ids = array_map( 'absint', $post_ids );
 		$site_id = absint( $assoc_args['site'] );
 		$this->_set_author( $assoc_args );
-		WP_CLI::line( sprintf( 'Starting import of %s posts from site %s', count( $post_ids ), $site_id ) );
+		WP_CLI::line( sprintf( __( 'Starting import of %s posts from site %s', 'simplechart' ), count( $post_ids ), $site_id ) );
 		foreach ( $post_ids as $post_id ) {
 			$post_object = $this->_extract_wpcom_post_object( $site_id, $post_id );
 			if ( $post_object ) {
@@ -65,7 +65,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 				$this->_load_post( $transformed );
 			}
 		}
-		WP_CLI::success( sprintf( 'Processed %s posts from site %s', count( $post_ids ), $site_id ) );
+		WP_CLI::success( sprintf( __( 'Processed %s posts from site %s', 'simplechart' ), count( $post_ids ), $site_id ) );
 	}
 
 	/**
@@ -85,12 +85,12 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 
 		// validate response
 		if ( is_wp_error( $response ) ) {
-			$warning = sprintf( "Failed to GET post %s from site %s\n", $post, $site );
+			$warning = sprintf( __( "Failed to GET post %s from site %s\n", 'simplechart' ), $post, $site );
 			$warning .= implode( "\n", $response->get_error_messages() );
 			WP_CLI::warning( $warning );
 			return null;
 		} elseif ( 200 !== $code = wp_remote_retrieve_response_code( $response ) ) {
-			WP_CLI::warning( sprintf( 'Post %s from site %s returned error code %s', $post, $site, $code ) );
+			WP_CLI::warning( sprintf( __( 'Post %s from site %s returned error code %s', 'simplechart' ), $post, $site, $code ) );
 			return null;
 		}
 
@@ -98,7 +98,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 
 		// make sure it's the right post type
 		if ( $this->_post_type !== $post_object['type'] ) {
-			WP_CLI::warning( sprintf( "Post %s from site %s does not have post_type '%s'", $post, $site, $this->_post_type ) );
+			WP_CLI::warning( sprintf( __( "Post %s from site %s does not have post_type '%s'", 'simplechart' ), $post, $site, $this->_post_type ) );
 			return null;
 		}
 
@@ -162,7 +162,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 	 */
 	private function _load_post( $data ) {
 		if ( empty( $data['post_data'] ) ) {
-			WP_CLI::warning( 'Tried to insert post with no post_data' );
+			WP_CLI::warning( __( 'Tried to insert post with no post_data', 'simplechart' ) );
 			return false;
 		}
 
@@ -194,7 +194,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 	private function _attach_featured_image_to_post( $image, $post_id, $desc ) {
 		$tmp = download_url( $image );
 		if ( is_wp_error( $tmp ) ) {
-			WP_CLI::warning( 'Error downloading ' . $image );
+			WP_CLI::warning( sprintf( __( 'Error downloading %s', 'simplechart' ), esc_url( $image ) ) );
 			if ( file_exists( $tmp ) ) {
 				@unlink( $tmp );
 			}

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -136,14 +136,7 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 		}
 
 		// featured image
-		$featured_image = null;
-		if ( ! empty( $post_object['post_thumbnail' ] ) ) {
-			$featured_image = array(
-				'url' => $post_object['post_thumbnail' ]['URL'],
-				'width' => $post_object['post_thumbnail' ]['width'],
-				'height' => $post_object['post_thumbnail' ]['height'],
-			);
-		}
+		$featured_image = ! empty( $post_object['featured_image'] ) ? $post_object['featured_image'] : null;
 
 		return array(
 			'post_data' => $post_data,
@@ -178,8 +171,8 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 		}
 
 		// attach the featured image
-		if ( $post_data['featured_image'] ) {
-			$this->_attach_featured_image_to_post( $post_data['featured_image']['url'], $post_id, $data['post_data']['post_title'] );
+		if ( $data['featured_image'] ) {
+			$this->_attach_featured_image_to_post( $data['featured_image'], $post_id, $data['post_data']['post_title'] );
 		}
 
 		return true;

--- a/modules/class-simplechart-wp-cli.php
+++ b/modules/class-simplechart-wp-cli.php
@@ -69,32 +69,6 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 	}
 
 	/**
-	 * set author by ID or username to assign imported posts to
-	 * @var array Assoc args from command
-	 */
-	private function _set_author( $assoc_args ) {
-		// was an author provided?
-		if ( empty( $assoc_args['author'] ) ) {
-			return;
-		}
-
-		// check for author ID
-		if ( is_numeric( $assoc_args['author'] ) ) {
-			$user = get_user_by( 'id', absint( $assoc_args['author'] ) );
-		}
-		// check for author by slug
-		else {
-			$user = get_user_by( 'slug', $assoc_args['author'] );
-		}
-
-		// set author
-		if ( ! empty( $user ) ) {
-			$this->_author = $user->ID;
-		}
-		return;
-	}
-
-	/**
 	 * Retrieve a single post from the WordPress.com REST API
 	 * see https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/%24post_ID/#apidoc-response
 	 * @param int $site WPCOM site ID
@@ -218,6 +192,32 @@ class Simplechart_WP_CLI extends WP_CLI_Command {
 	 */
 	private function _attach_featured_image_to_post( $image, $post_id ) {
 		// https://codex.wordpress.org/Function_Reference/media_handle_sideload#Examples
+	}
+
+	/**
+	 * set author by ID or username to assign imported posts to
+	 * @var array Assoc args from command
+	 */
+	private function _set_author( $assoc_args ) {
+		// was an author provided?
+		if ( empty( $assoc_args['author'] ) ) {
+			return;
+		}
+
+		// check for author ID
+		if ( is_numeric( $assoc_args['author'] ) ) {
+			$user = get_user_by( 'id', absint( $assoc_args['author'] ) );
+		}
+		// check for author by slug
+		else {
+			$user = get_user_by( 'slug', $assoc_args['author'] );
+		}
+
+		// set author
+		if ( ! empty( $user ) ) {
+			$this->_author = $user->ID;
+		}
+		return;
 	}
 }
 WP_CLI::add_command( 'simplechart', 'Simplechart_WP_CLI' );

--- a/simplechart.php
+++ b/simplechart.php
@@ -132,6 +132,11 @@ class Simplechart {
 		require_once( $this->_plugin_dir_path . 'modules/class-simplechart-template.php' );
 		$this->template = new Simplechart_Template;
 
+		// WP-CLI commands
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			require_once( $this->_plugin_dir_path . 'modules/class-simplechart-wp-cli.php' );
+		}
+
 	}
 
 	/**


### PR DESCRIPTION
Requires remote site ID and comma-separated list of post IDs, optional author ID or username to assign imported posts to.

Could be extended later for WP-API use by writing different methods to `extract` and `transform`, and using the same `load` method.
