### PR TITLE
Media library fixes

### DIFF
--- a/js/post-edit.js
+++ b/js/post-edit.js
@@ -8,8 +8,10 @@ function WPSimplechartApp(){
 		modalInitialized : false,
 		chartData : null,
 		childWindow : null,
+		confirmNoDataMessage : '',
 
 		init : function() {
+			this.confirmNoDataMessage = WPSimplechartBootstrap.confirmNoDataMessage;
 			window.addEventListener('message', this.receiveMessages );
 			this.inputEl = document.getElementById( WPSimplechartBootstrap.postmetaKey );
 			this.inputTemplateEl = document.getElementById( 'simplechart-template' );
@@ -44,7 +46,9 @@ function WPSimplechartApp(){
 				$( 'body' ).append( app.modalElements.container + app.modalElements.backdrop );
 				$( '#simplechart-close' ).click( function( e ) {
 					e.preventDefault();
-					$( '#simplechart-backdrop, #simplechart-modal' ).hide();
+					if ( app.chartData || confirm( app.confirmNoDataMessage ) ) {
+						$( '#simplechart-backdrop, #simplechart-modal' ).hide();
+					}
 				} );
 
 				app.modalInitialized = true;

--- a/js/post-edit.js
+++ b/js/post-edit.js
@@ -9,6 +9,7 @@ function WPSimplechartApp(){
 		chartData : null,
 		childWindow : null,
 		confirmNoDataMessage : '',
+		savedChart : false,
 
 		init : function() {
 			this.confirmNoDataMessage = WPSimplechartBootstrap.confirmNoDataMessage;
@@ -46,8 +47,9 @@ function WPSimplechartApp(){
 				$( 'body' ).append( app.modalElements.container + app.modalElements.backdrop );
 				$( '#simplechart-close' ).click( function( e ) {
 					e.preventDefault();
-					if ( app.chartData || confirm( app.confirmNoDataMessage ) ) {
+					if ( app.savedChart || confirm( app.confirmNoDataMessage ) ) {
 						$( '#simplechart-backdrop, #simplechart-modal' ).hide();
+						app.savedChart = false;
 					}
 				} );
 
@@ -108,6 +110,7 @@ function WPSimplechartApp(){
 				$title.val( decodeURIComponent( app.chartData.meta.title ) ).focus();
 			}
 
+			app.savedChart = true;
 			console.log( 'parent window received data from app iframe' );
 			console.log( app.inputTemplateEl.value, app.chartData );
 

--- a/js/post-edit.js
+++ b/js/post-edit.js
@@ -9,7 +9,7 @@ function WPSimplechartApp(){
 		chartData : null,
 		childWindow : null,
 
-		init : function(){
+		init : function() {
 			window.addEventListener('message', this.receiveMessages );
 			this.inputEl = document.getElementById( WPSimplechartBootstrap.postmetaKey );
 			this.inputTemplateEl = document.getElementById( 'simplechart-template' );
@@ -23,13 +23,13 @@ function WPSimplechartApp(){
 			$( '#simplechart-launch' ).click();
 		},
 
-		setAppOrigin : function(){
+		setAppOrigin : function() {
 			var tempEl = document.createElement( 'a' );
 			tempEl.href = WPSimplechartBootstrap.appUrl;
 			return tempEl.origin;
 		},
 
-		clearInputEl : function(e){
+		clearInputEl : function(e) {
 			e.preventDefault();
 			app.inputEl.setAttribute('value', '');
 			app.inputTemplateEl.setAttribute('value', '');
@@ -42,7 +42,8 @@ function WPSimplechartApp(){
 				app.modalElements.container = app.modalElements.container.replace('{{iframeSrc}}', WPSimplechartBootstrap.appUrl);
 				app.modalElements.container = app.modalElements.container.replace('{{closeModal}}', WPSimplechartBootstrap.closeModal);
 				$( 'body' ).append( app.modalElements.container + app.modalElements.backdrop );
-				$( '#simplechart-close' ).click( function(){
+				$( '#simplechart-close' ).click( function( e ) {
+					e.preventDefault();
 					$( '#simplechart-backdrop, #simplechart-modal' ).hide();
 				} );
 
@@ -55,7 +56,7 @@ function WPSimplechartApp(){
 		/*
 		 * postMessage send/receive functions
 		 */
-		receiveMessages: function(e) {
+		receiveMessages: function( e ) {
 			if ( _.isUndefined( e.data.src ) || 'simplechart' !== e.data.src ) {
 				return;
 			}
@@ -66,7 +67,7 @@ function WPSimplechartApp(){
 				return;
 			}
 
-			if ( app.isFrameReadyMessage( e.data ) ){
+			if ( app.isFrameReadyMessage( e.data ) ) {
 				console.log( 'window received ready message from Simplechart iframe');
 				app.childWindow = app.childWindow || document.getElementById('simplechart-frame').contentWindow;
 				app.sendSimplechartOptions();
@@ -88,18 +89,18 @@ function WPSimplechartApp(){
 			app.imgInputEl.value = e.data.data.chartImg;
 
 			// store published chart URL
-			if ( ! _.isUndefined( app.chartData.chartUrl ) ){
+			if ( ! _.isUndefined( app.chartData.chartUrl ) ) {
 				app.inputChartUrlEl.value = app.chartData.chartUrl;
 			}
 
 			// store published chart ID
-			if ( ! _.isUndefined( app.chartData.id ) ){
+			if ( ! _.isUndefined( app.chartData.id ) ) {
 				app.inputChartIdEl.value = app.chartData.id;
 			}
 
 			// set post title to chart name if empty
 			$title =  $( '#title' );
-			if ( ! $title.val() ){
+			if ( ! $title.val() ) {
 				$title.val( decodeURIComponent( app.chartData.meta.title ) ).focus();
 			}
 
@@ -123,7 +124,7 @@ function WPSimplechartApp(){
 			app.childWindow.postMessage( msgObj, app.appOrigin );
 		},
 
-		sendSavedData : function(){
+		sendSavedData : function() {
 			var mergedFields = WPSimplechartBootstrap.data || null;
 			if ( mergedFields ){
 				mergedFields.template = WPSimplechartBootstrap.template;
@@ -138,7 +139,7 @@ function WPSimplechartApp(){
 			app.childWindow.postMessage( msgObj, app.appOrigin );
 		},
 
-		isFrameReadyMessage : function(msgObj){
+		isFrameReadyMessage : function(msgObj) {
 			return !_.isUndefined( msgObj.channel ) &&
 				msgObj.channel === 'upstream' &&
 				!_.isUndefined( msgObj.msg ) &&
@@ -147,12 +148,12 @@ function WPSimplechartApp(){
 	};
 
 	// initialize when document is ready;
-	if ( typeof $ === 'undefined' ){
+	if ( typeof $ === 'undefined' ) {
 		var $ = jQuery;
 	}
-	$(document).ready(function(){
+	$( document ).ready( function() {
 		app.init();
-	});
+	} );
 
 	return app;
 };

--- a/modules/class-simplechart-post-type.php
+++ b/modules/class-simplechart-post-type.php
@@ -82,6 +82,7 @@ class Simplechart_Post_Type {
 			json_encode( json_decode( $json_data ) ), // escapes without converting " to &quot
 			Simplechart::instance()->save->validate_template_fragment( $template_html ),
 			__( 'Close Modal', 'simplechart' ),
+			__( 'Confirming this message will proceed without saving changes. If you have made changes that you wish to save, cancel this message, proceed to the final step, and click the Save Chart button.', 'simplechart' ),
 			esc_attr( $nonce ),
 			json_encode( json_decode( $json_data ) ),
 			esc_attr( $template_html ),

--- a/modules/class-simplechart-save.php
+++ b/modules/class-simplechart-save.php
@@ -86,7 +86,7 @@ class Simplechart_Save {
 		}
 
 		// handle base64 image string if provided
-		if ( ! empty( $_POST['simplechart-png-string'] ) && in_array( get_post_status( $post->ID ), array( 'publish', 'future' ), true ) ){
+		if ( ! empty( $_POST['simplechart-png-string'] ) ){
 			$this->_save_chart_image( $post, $_POST['simplechart-png-string'], $this->_default_img_type );
 		}
 

--- a/modules/class-simplechart-save.php
+++ b/modules/class-simplechart-save.php
@@ -202,7 +202,7 @@ class Simplechart_Save {
 	}
 
 	public function set_chart_image_status( $data, $postarr ) {
-		if ( ! empty( $data['ID'] ) && ! empty( $this->_attachment_id ) && $this->_attachment_id === $data['ID'] ) {
+		if ( 'simplechart' === get_post_type( $data['post_parent'] ) ) {
 			$data['post_status'] = $this->_image_post_status;
 		}
 		return $data;

--- a/templates/meta-box.html
+++ b/templates/meta-box.html
@@ -7,7 +7,8 @@
 		postmetaKey : "%s",
 		data : %s,
 		template : '%s',
-		closeModal : '%s'
+		closeModal : '%s',
+		confirmNoDataMessage : '%s'
 	};
 </script>
 <input type="hidden" id="simplechart-nonce" name="simplechart-nonce" value="%s" />


### PR DESCRIPTION
- create thumbnail for chart regardless of its `post_status`
- use custom status for the thumbnail `attachment` so it gets ignored by the query that populates the Media Library
- alert user if they are closing the app modal without saving data
