### PR TITLE
receive message from localhost iframe

### DIFF
--- a/js/plugin/post-edit.js
+++ b/js/plugin/post-edit.js
@@ -78,10 +78,6 @@ function WPSimplechartApp( $ ) {
 		}
 
 		switch( true ) {
-			case 'localhostUpdate' === messageType:
-				applyLocalhostUpdate(evt);
-				break;
-
 			case 'appReady' === messageType:
 				sendData();
 				break;
@@ -116,20 +112,6 @@ function WPSimplechartApp( $ ) {
 		Object.keys( window.WPSimplechartBootstrap ).forEach( function( key ) {
 			sendDataKeyMessage( childWindow.contentWindow, key );
 		} );
-	}
-
-	/**
-	 * Log latest action and allow inspection of app state from localhost
-	 * Gets around cross-origin iframe limitations during development
-	 */
-	function applyLocalhostUpdate(evt) {
-		if ( ! isLocalhost( evt.origin ) ) {
-			return;
-		}
-		if (window._simplechartStoreLogger) {
-			console.log( evt.data.data.action, evt.data.data.update );
-		}
-		window._simplechartStoreData = evt.data.data.store || 'missing evt.data.store';
 	}
 
 	/**
@@ -183,13 +165,6 @@ function WPSimplechartApp( $ ) {
 	// GO GO GO
 	init();
 }
-
-// Setup function to log store contents during local iframe development
-window._simplechartStore = function() {
-	console.log( window._simplechartStoreData || 'Simplechart store not initialized' );
-}
-// Set this to false to turn off logging via middleware/localhostLogger
-window._simplechartStoreLogger = true;
 
 if ( 'undefined' !== typeof pagenow && 'simplechart' === pagenow ){
 	jQuery( document ).ready( function() {

--- a/js/plugin/post-edit.js
+++ b/js/plugin/post-edit.js
@@ -54,7 +54,7 @@ function WPSimplechartApp( $ ) {
 	 */
 	function getMessageType( evt ) {
 		// confirm same-origin or http(s)://localhost:8080
-		if ( evt.origin !== window.location.origin && !isLocalhost(evt.origin) ) {
+		if ( evt.origin !== window.location.origin && !/https?:\/\/localhost:8080/.test( evt.origin ) ) {
 			return false;
 		}
 
@@ -153,13 +153,6 @@ function WPSimplechartApp( $ ) {
 		if ( 'save-chartOptions' === messageType && data.height ) {
 			document.getElementById( 'save-height' ).value = data.height;
 		}
-	}
-
-	/**
-	 * Is origin http(s)://localhost:8080?
-	 */
-	function isLocalhost( origin ) {
-		return /https?:\/\/localhost:8080/.test( origin );
 	}
 
 	// GO GO GO

--- a/simplechart.php
+++ b/simplechart.php
@@ -176,17 +176,19 @@ class Simplechart {
 		 */
 		$use_localhost = apply_filters( 'simplechart_use_localhost', $use_localhost );
 
+		// Set URLs for JS app and widget
 		if ( $use_localhost ) {
-			$this->_config['web_app_iframe_src'] = 'http://localhost:8080/';
 			$this->_config['web_app_js_url'] = 'http://localhost:8080/static/app.js';
 			$this->_config['widget_loader_url'] = 'http://localhost:8080/static/widget.js';
 		} else {
-			// menu page set up by Simplechart_Post_Type module
-			$this->_config['web_app_iframe_src'] = admin_url( '/admin.php?page=' . $this->get_config( 'menu_page_slug' ) . '&noheader' );
 			$this->_config['web_app_js_url'] = $this->get_plugin_url( 'js/app/app.a77ffdb.js' );
 			$this->_config['widget_loader_url'] = $this->get_plugin_url( 'js/app/widget.a77ffdb.js' );
 		}
 
+		// URL for menu page set up by Simplechart_Post_Type module
+		$this->_config['web_app_iframe_src'] = admin_url( '/admin.php?page=' . $this->get_config( 'menu_page_slug' ) . '&noheader' );
+
+		// Filters for app page and JS URLs
 		$this->_config['web_app_iframe_src'] = apply_filters( 'simplechart_web_app_iframe_src', $this->_config['web_app_iframe_src'] );
 		$this->_config['web_app_js_url'] = apply_filters( 'simplechart_web_app_js_url', $this->_config['web_app_js_url'] );
 		$this->_config['widget_loader_url'] = apply_filters( 'simplechart_widget_loader_url', $this->_config['widget_loader_url'] );

--- a/templates/iframe.php
+++ b/templates/iframe.php
@@ -5,8 +5,8 @@
 <!DOCTYPE html>
 <html>
 	<head lang="en">
-	<meta charset="UTF-8">
-	<title>Simplechart</title>
+		<meta charset="UTF-8">
+		<title>Simplechart</title>
 		<style>
 			body {
 			margin: 0;
@@ -19,6 +19,11 @@
 				height: 100%;
 			}
 		</style>
+		<script>
+			if ( window.parent && window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__ ) {
+				window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+			}
+		</script>
 	</head>
 	<body>
 	<div id='app'></div>

--- a/templates/iframe.php
+++ b/templates/iframe.php
@@ -20,6 +20,9 @@
 			}
 		</style>
 		<script>
+			/**
+			 * Give React Dev Tools access to iframe
+			 */
 			if ( window.parent && window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__ ) {
 				window.__REACT_DEVTOOLS_GLOBAL_HOOK__ = window.parent.__REACT_DEVTOOLS_GLOBAL_HOOK__;
 			}


### PR DESCRIPTION
~~because React dev tools can't access the cross-origin iframe~~

Allow React Dev Tools to access iframe by loading only the JS from `localhost:8080`, as opposed to the underlying HTML page.
