### PR TITLE
Add example of filtering headers for SimpleChart API

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ Defaults to `false`. If `true`, the plugin will display extra debugging notices 
 
 ##### simplechart_api_http_headers
 
-Apply any headers to the request made to Simplechart's API before rendering a chart in a front-end template. Useful for dev sites protected by `.htaccess` passwords.
+Apply any headers to the request made to Simplechart's API before rendering a chart in a front-end template. Useful for dev sites protected by `.htaccess` passwords, for instance:
+```
+add_filter( 'simplechart_api_http_headers', function( $headers ) {
+  $headers['Authorization'] = 'Basic ' . base64_encode( 'username:password' );
+  return $headers;
+} );
+```
 
 ##### simplechart_widget_template
 


### PR DESCRIPTION
Include example of filtering SC headers so that embeds can be used on sites protected with `.htaccess`.