### PR TITLE
Check `window.pagenow` to avoid "not defined" error

### DIFF
--- a/js/plugin/plugin.js
+++ b/js/plugin/plugin.js
@@ -3,7 +3,7 @@
  * try to update Simplechart as if it was hosted on WP.org
  */
 jQuery( document ).ready( function( $ ) {
-	if ( 'plugins' !== pagenow ) {
+	if ( 'plugins' !== window.pagenow ) {
 		return;
 	}
 


### PR DESCRIPTION
`pagenow` isn't defined in the Customizer, which generates an "is not defined" error on this line.