### PR TITLE
BR-1821 Prevent wp_unslash from breaking escaped chars in data or metadata

### DIFF
--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -38,7 +38,11 @@
 		<type>warning</type>
 	</rule>
 
+	<!-- https://github.com/WordPress-Coding-Standards/WordPress-Coding-Standards/issues/172 -->
 	<rule ref="WordPress.VIP.ValidatedSanitizedInput.MissingUnslash">
+		<exclude-pattern>modules/class-simplechart-save.php</exclude-pattern>
+	</rule>
+	<rule ref="WordPress.Security.ValidatedSanitizedInput.MissingUnslash">
 		<exclude-pattern>modules/class-simplechart-save.php</exclude-pattern>
 	</rule>
 

--- a/codesniffer.ruleset.xml
+++ b/codesniffer.ruleset.xml
@@ -34,8 +34,12 @@
 	</rule>
 
 	<!-- Tweak the VIP rules -->
-	<rule ref="WordPress.XSS.EscapeOutput.OutputNotEscaped">
+	<rule ref="WordPress.Security.EscapeOutput.OutputNotEscaped">
 		<type>warning</type>
+	</rule>
+
+	<rule ref="WordPress.VIP.ValidatedSanitizedInput.MissingUnslash">
+		<exclude-pattern>modules/class-simplechart-save.php</exclude-pattern>
 	</rule>
 
 </ruleset>

--- a/modules/class-simplechart-save.php
+++ b/modules/class-simplechart-save.php
@@ -93,7 +93,7 @@ class Simplechart_Save {
 		foreach ( array( 'chartData', 'chartOptions', 'chartMetadata', 'googleSheetId' ) as $field ) {
 			if ( ! empty( $_POST[ 'save-' . $field ] ) ) {
 				// sanitize field name w/ esc_attr() instead of sanitize_key() because we want to preserve uppercase letters
-				update_post_meta( $post->ID, 'save-' . esc_attr( $field ), sanitize_text_field( wp_unslash( $_POST[ 'save-' . $field ] ) ) );
+				update_post_meta( $post->ID, 'save-' . esc_attr( $field ), sanitize_text_field( $_POST[ 'save-' . $field ] ) );
 			}
 		}
 

--- a/simplechart.php
+++ b/simplechart.php
@@ -4,7 +4,7 @@ Plugin Name: Simplechart
 Plugin URI: https://github.com/alleyinteractive/wordpress-simplechart
 Description: Create and render interactive charts in WordPress using Simplechart
 Author: Drew Machat, Josh Kadis, Alley Interactive
-Version: 0.5.15
+Version: 0.5.16
 Author URI: http://www.alleyinteractive.com/
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
@@ -30,7 +30,7 @@ class Simplechart {
 		'webpack_public_path' => null,
 		'widget_loader_url' => null,
 		'menu_page_slug' => 'simplechart_app',
-		'version' => '0.5.15',
+		'version' => '0.5.16',
 		'app_version' => 'ca57f25',
 	);
 


### PR DESCRIPTION
Before, with `wp_unslash()`:

![screen shot 2017-12-13 at 2 06 02 pm](https://user-images.githubusercontent.com/997097/33957270-1c7340b6-e00f-11e7-865c-0be2cf3bb3aa.png)

After, without `wp_unslash()`

![screen shot 2017-12-13 at 2 07 58 pm](https://user-images.githubusercontent.com/997097/33957282-2914d12c-e00f-11e7-9c5c-99ed2955292c.png)
