### PR TITLE
Close script tags after rendering template

### DIFF
--- a/modules/class-simplechart-insert-template.php
+++ b/modules/class-simplechart-insert-template.php
@@ -70,7 +70,6 @@ class Simplechart_Insert_Template {
 
 			<div class="spinner"></div>
 		</form>
-	</script>
 	<?php
 	}
 
@@ -84,5 +83,14 @@ class Simplechart_Insert_Template {
 		?>
 		<script type="text/html" id="tmpl-<?php echo esc_attr( $id ); ?>">
 			<?php
+	}
+
+	/**
+	 * Outputs the markup needed after a template.
+	 */
+	final public function after_template() {
+		?>
+		</script>
+		<?php
 	}
 }

--- a/modules/class-simplechart-insert.php
+++ b/modules/class-simplechart-insert.php
@@ -148,12 +148,14 @@ class Simplechart_Insert {
 
 			$template->before_template( $id );
 			call_user_func( array( $template, $t ), $id, 'all' );
+			$template->after_template();
 		}
 
 		$id = sprintf( 'simplechart-insert-thumbnail' );
 
 		$template->before_template( $id );
 		call_user_func( array( $template, 'thumbnail' ), $id );
+		$template->after_template();
 	}
 
 	/**


### PR DESCRIPTION
The `#tmpl-simplechart-insert-item-all` and `#tmpl-simplechart-insert-thumbnail` templates are currently missing `</script>` tags, which prevents the Customizer from loading when the Simplechart plugin is enabled.